### PR TITLE
Backport TCP backlog size update of uint16->uint32 with Linux

### DIFF
--- a/tcplisten_linux.go
+++ b/tcplisten_linux.go
@@ -47,13 +47,69 @@ func soMaxConn() (int, error) {
 		return -1, fmt.Errorf("cannot parse somaxconn %q read from %s: %s", s, soMaxConnFilePath, err)
 	}
 
-	// Linux stores the backlog in a uint16.
-	// Truncate number to avoid wrapping.
-	// See https://github.com/golang/go/issues/5030 .
 	if n > 1<<16-1 {
-		n = 1<<16 - 1
+		n = maxAckBacklog(n)
 	}
 	return n, nil
 }
+
+func kernelVersion() (major int, minor int) {
+  var uname syscall.Utsname
+	if err := syscall.Uname(&uname); err != nil {
+		return
+	}
+
+	rl := uname.Release
+	var values [2]int
+	vi := 0
+	value := 0
+	for _, c := range rl {
+		if c >= '0' && c <= '9' {
+			value = (value * 10) + int(c-'0')
+		} else {
+			// Note that we're assuming N.N.N here.  If we see anything else we are likely to
+			// mis-parse it.
+			values[vi] = value
+			vi++
+			if vi >= len(values) {
+				break
+			}
+		}
+	}
+	switch vi {
+	case 0:
+		return 0, 0
+	case 1:
+		return values[0], 0
+	case 2:
+		return values[0], values[1]
+	}
+	return
+}
+
+// Linux stores the backlog as:
+//
+//  - uint16 in kernel version < 4.1,
+//  - uint32 in kernel version >= 4.1
+//
+// Truncate number to avoid wrapping.
+//
+// See issue 5 or
+// https://github.com/golang/go/issues/5030.
+// https://github.com/golang/go/issues/41470.
+func maxAckBacklog(n int) int {
+	major, minor := kernelVersion()
+	size := 16
+	if major > 4 || (major == 4 && minor >= 1) {
+		size = 32
+	}
+
+	var max uint = 1<<size - 1
+	if uint(n) > max {
+		n = int(max)
+	}
+	return n
+}
+
 
 const soMaxConnFilePath = "/proc/sys/net/core/somaxconn"


### PR DESCRIPTION
Max tcp backlog was increased from uint16 to uint32 in kernel
version 4.1 and above.
This commit is backport by https://golang.org/cl/255898