### PR TITLE
add support for dual-stack socket

### DIFF
--- a/tcplisten.go
+++ b/tcplisten.go
@@ -129,10 +129,6 @@ func (cfg *Config) fdSetup(fd int, sa syscall.Sockaddr, addr string) error {
 }
 
 func getSockaddr(network, addr string) (sa syscall.Sockaddr, soType int, err error) {
-	if network != "tcp4" && network != "tcp6" {
-		return nil, -1, errors.New("only tcp4 and tcp6 network is supported")
-	}
-
 	tcpAddr, err := net.ResolveTCPAddr(network, addr)
 	if err != nil {
 		return nil, -1, err
@@ -156,7 +152,22 @@ func getSockaddr(network, addr string) (sa syscall.Sockaddr, soType int, err err
 			sa6.ZoneId = uint32(ifi.Index)
 		}
 		return &sa6, syscall.AF_INET6, nil
+	case "tcp":
+		var sa6 syscall.SockaddrInet6
+		sa6.Port = tcpAddr.Port
+		if tcpAddr.IP == nil {
+			tcpAddr.IP = net.IPv4(0,0,0,0)
+		}
+		copy(sa6.Addr[:], tcpAddr.IP.To16())
+		if tcpAddr.Zone != "" {
+			ifi, err := net.InterfaceByName(tcpAddr.Zone)
+			if err != nil {
+				return nil, -1, err
+			}
+			sa6.ZoneId = uint32(ifi.Index)
+		}
+		return &sa6, syscall.AF_INET6, nil
 	default:
-		return nil, -1, errors.New("Unknown network type " + network)
+		return nil, -1, errors.New("only tcp, tcp4, or tcp6 is supported: " + network)
 	}
 }

--- a/tcplisten_test.go
+++ b/tcplisten_test.go
@@ -37,6 +37,8 @@ func TestConfigBacklog(t *testing.T) {
 }
 
 func testConfig(t *testing.T, cfg Config) {
+	testConfigV(t, cfg, "tcp",  "localhost:10081")
+	testConfigV(t, cfg, "tcp",  "ip6-localhost:10081")
 	testConfigV(t, cfg, "tcp4", "localhost:10081")
 	testConfigV(t, cfg, "tcp6", "ip6-localhost:10081")
 }


### PR DESCRIPTION
This change allows TCP networks for dual-stack IPv4-mapped IPv6 addresses.